### PR TITLE
Bug Fixes: Map, Territories, PlayerStrategies, GameEngine

### DIFF
--- a/include/CommandProcessing.h
+++ b/include/CommandProcessing.h
@@ -4,7 +4,7 @@
 #include <fstream>
 #include "LoggingObserver.h"
 
-class Command: public Subject, public ILoggable {
+class Command : public Subject, public ILoggable {
 public:
     std::string commandText;
     std::string effect;
@@ -15,7 +15,7 @@ public:
     string stringToLog() override;
 };
 
-class CommandProcessor: public Subject, public ILoggable  {
+class CommandProcessor : public Subject, public ILoggable {
 public:
     std::vector<Command*> commands;
 

--- a/include/GameEngine.h
+++ b/include/GameEngine.h
@@ -12,9 +12,9 @@ class Player;
 
 using std::string;
 
-class GameEngine: public Subject, public ILoggable {
+class GameEngine : public Subject, public ILoggable {
 
-    private:
+private:
     string currentState;
     Map* gameMap;
     vector<Player*> participants;
@@ -23,7 +23,7 @@ class GameEngine: public Subject, public ILoggable {
     Player* neutralPlayer;
 
 
-    public:
+public:
     GameEngine(const string& state);
     ~GameEngine();
     string getState() const;

--- a/include/Map.h
+++ b/include/Map.h
@@ -29,10 +29,10 @@ class Map {
 
 private:
 	map<string, Territory*> territories;
-	map<string, Continent*> continents;	
+	map<string, Continent*> continents;
 
 public:
-	
+
 	// Default constructor
 	Map();
 
@@ -46,12 +46,12 @@ public:
 	// Destructor
 	~Map();
 
-	
+
 	void dfs(Territory* territory, unordered_set<string>& visited) const;
 
-	map<string, Territory*> getTerritories() ;
+	map<string, Territory*> getTerritories();
 
-	map<string, Continent*> getContinents() ;
+	map<string, Continent*> getContinents();
 	vector<Continent*> getContinentsVector();
 	vector<Territory*> getTerritoriesVector();
 
@@ -59,17 +59,17 @@ public:
 	//create a new territry, add it to territories map, and return its pointer
 	Territory* addTerritory(const string& name);
 
-	Continent* addContinent(const string& name) ;
+	Continent* addContinent(const string& name);
 
 	//connect 2 territories in map
 	void connect(const string& name1, const string& name2);
 
-	void display() const ;
+	void display() const;
 
 
-	bool areContinentsSubgraphs() ;
+	bool areContinentsSubgraphs();
 
-	bool isMapConnected() ;
+	bool isMapConnected();
 
 	bool validate();
 

--- a/include/Player.h
+++ b/include/Player.h
@@ -3,7 +3,7 @@
 *   declarations for the object Player.
 *
 *   Written by: Mark Kandaleft
-*   For COMP 345 
+*   For COMP 345
 */
 
 #pragma once
@@ -23,43 +23,44 @@ class PlayerStrategy;
 
 class Player {
 
-    private:
-        string name;
-        vector<Territory*> territories;
-        OrdersList* ordersList;
-        Hand* hand;
-        int reinforcementPool;
-        vector<Player*> alliances;
-        PlayerStrategy* strat;
+private:
+    string name;
+    vector<Territory*> territories;
+    OrdersList* ordersList;
+    Hand* hand;
+    int reinforcementPool;
+    vector<Player*> alliances;
+    PlayerStrategy* strat;
 
-        bool beenAttacked;
+    bool beenAttacked;
 
-    public:
-        Player(const string& playerName);
-        Player(const string& playerName, PlayerStrategy* plan);
-        ~Player();
-        void addTerritory(Territory& territory);
-        const vector<Territory*> toDefend();
-        const vector<Territory*> toAttack();
-        void issueOrder(Player* player, GameEngine* game);
-        string getName() const;
-        Player(const Player& player);
-        vector<Territory*> getTerritories() const;
-        int getReinforcement() const;
-        void earnReinforcement(int added);
-        void useReinforcement(int used);
-        int getPoolSize();
-        Hand* getHand();
-        OrdersList* getOrdersList();
-        bool operator==(const Player& other) const;
-        vector<Player*> getAlliances();
-        void addAlliance(Player* ally);
-        
-        void setName(const string& newName);
+public:
+    Player(const string& playerName);
+    Player(const string& playerName, PlayerStrategy* plan);
+    ~Player();
+    void addTerritory(Territory& territory);
+    const vector<Territory*> toDefend();
+    const vector<Territory*> toAttack();
+    void issueOrder(Player* player, GameEngine* game);
+    string getName() const;
+    Player(const Player& player);
+    vector<Territory*> getTerritories() const;
+    int getReinforcement() const;
+    void earnReinforcement(int added);
+    void useReinforcement(int used);
+    int getPoolSize();
+    Hand* getHand();
+    OrdersList* getOrdersList();
+    bool operator==(const Player& other) const;
+    vector<Player*> getAlliances();
+    void addAlliance(Player* ally);
 
-        void setBeenAttacked(bool status);
-        bool getBeenAttacked();
-        vector<Territory*> getSurroundings();
-        void setStrategy(PlayerStrategy* plan);
+    void setName(const string& newName);
+
+    void setBeenAttacked(bool status);
+    bool getBeenAttacked();
+    vector<Territory*> getSurroundings();
+    void setStrategy(PlayerStrategy* plan);
 
 };
+

--- a/include/PlayerStrategies.h
+++ b/include/PlayerStrategies.h
@@ -4,37 +4,37 @@
 #include "GameEngine.h"
 #include "Player.h"
 
-class PlayerStrategy{
-    private:
+class PlayerStrategy {
+private:
 
-    public:
-        virtual void issueOrder(Player* player,GameEngine* theGame) = 0;
-        virtual vector<Territory*> toAttack(Player* player) = 0;
-        virtual vector<Territory*> toDefend(Player* player) = 0;
+public:
+    virtual void issueOrder(Player* player, GameEngine* theGame) = 0;
+    virtual vector<Territory*> toAttack(Player* player) = 0;
+    virtual vector<Territory*> toDefend(Player* player) = 0;
 
 };
 
 /*
 requires user interactions to make decisions, including deploy and advance orders, as well as
-playing any card. 
+playing any card.
 */
-class Human : public PlayerStrategy{
-    public: 
-        void issueOrder(Player* player,GameEngine* theGame);
-        vector<Territory*> toAttack(Player* player);
-        vector<Territory*> toDefend(Player* player);
+class Human : public PlayerStrategy {
+public:
+    void issueOrder(Player* player, GameEngine* theGame);
+    vector<Territory*> toAttack(Player* player);
+    vector<Territory*> toDefend(Player* player);
 };
 
 /*
 computer player that focuses on attack (deploys or advances armies on its strongest
 country, then always advances to enemy territories until it cannot do so anymore; will use any card with an
-aggressive purpose, as defined above). 
+aggressive purpose, as defined above).
 */
-class Aggressive : public PlayerStrategy{
-    public:
-        void issueOrder(Player* player,GameEngine* theGame);
-        vector<Territory*> toAttack(Player* player);
-        vector<Territory*> toDefend(Player* player);
+class Aggressive : public PlayerStrategy {
+public:
+    void issueOrder(Player* player, GameEngine* theGame);
+    vector<Territory*> toAttack(Player* player);
+    vector<Territory*> toDefend(Player* player);
 
 };
 
@@ -42,34 +42,34 @@ class Aggressive : public PlayerStrategy{
 /*
 computer player that focuses on protecting its weak countries (deploys or advances armies
 on its weakest countries, never advances to enemy territories; may use cards but will never use a card in a way
-that purposefully will harm anyone). 
+that purposefully will harm anyone).
 */
-class Benevolent: public PlayerStrategy{
-    public:
-        void issueOrder(Player* player,GameEngine* theGame);        
-        vector<Territory*> toAttack(Player* player);
-        vector<Territory*> toDefend(Player* player);
+class Benevolent : public PlayerStrategy {
+public:
+    void issueOrder(Player* player, GameEngine* theGame);
+    vector<Territory*> toAttack(Player* player);
+    vector<Territory*> toDefend(Player* player);
 };
 
 /*
 computer player that never issues any order, nor uses any cards, though it may have or receive
-cards. If a Neutral player is attacked, it becomes an Aggressive player. 
+cards. If a Neutral player is attacked, it becomes an Aggressive player.
 */
-class Neutral: public PlayerStrategy{
-    public:
-        void issueOrder(Player* player,GameEngine* theGame);
-        vector<Territory*> toAttack(Player* player);
-        vector<Territory*> toDefend(Player* player);
+class Neutral : public PlayerStrategy {
+public:
+    void issueOrder(Player* player, GameEngine* theGame);
+    vector<Territory*> toAttack(Player* player);
+    vector<Territory*> toDefend(Player* player);
 };
 
 
 /*
 computer player that automatically conquers all territories that are adjacent to its own
-territories (only once per turn). Does not use cards, though it may have or receive cards. 
+territories (only once per turn). Does not use cards, though it may have or receive cards.
 */
-class Cheater: public PlayerStrategy{
+class Cheater : public PlayerStrategy {
 public:
-        void issueOrder(Player* player,GameEngine* theGame);
-        vector<Territory*> toAttack(Player* player);
-        vector<Territory*> toDefend(Player* player);
+    void issueOrder(Player* player, GameEngine* theGame);
+    vector<Territory*> toAttack(Player* player);
+    vector<Territory*> toDefend(Player* player);
 };

--- a/include/Territory.h
+++ b/include/Territory.h
@@ -33,7 +33,7 @@ public:
 	vector<Territory*> getAdjacents() const;
 	int getUnits();
 	Player* getOwner();
-	
+
 	void connect(Territory* other);
 
 	void setContinent(Continent* newContinent);

--- a/include/cards.h
+++ b/include/cards.h
@@ -17,14 +17,14 @@ class Card {
 public:
 	Card();
 
-	Card(Orders& type); 
+	Card(Orders& type);
 
 	Card(const Card& other);
 
 	void play(Deck& gameDeck, Hand& playerHand);
 
 	Orders* getType();
-	
+
 	int getId();
 	void addId();
 

--- a/src/CommandProcessing.cpp
+++ b/src/CommandProcessing.cpp
@@ -33,7 +33,7 @@ std::string CommandProcessor::readCommand() {
     std::string userInput;
     std::cout << "Enter a command: ";
     //std::cin.ignore(); // Clear any previous newline characters
-    getline(cin,userInput);
+    getline(cin, userInput);
     return userInput;
 }
 
@@ -125,3 +125,4 @@ void FileCommandProcessorAdapter::saveCommand(std::string s) {
 //
 //    return 0;
 //}
+

--- a/src/CommandProcessingDriver.cpp
+++ b/src/CommandProcessingDriver.cpp
@@ -4,15 +4,17 @@
 #include <cstdlib>
 #include <random>
 #include <sstream>
+
+#include "../include/GameEngine.h"
 #include "../include/CommandProcessing.h"
 
 void ExecuteCommand(string command, GameEngine* engine) {
 
     if (command.find("tournament", 0) == 0) {
-        
+
     }
-    if (command.find("loadmap",0)== 0) {
-       engine->loadMap(command);
+    if (command.find("loadmap", 0) == 0) {
+        engine->loadMap(command);
     }
     else if (command.find("loadmap", 0) == 0) {
         engine->loadMap(command);
@@ -23,7 +25,7 @@ void ExecuteCommand(string command, GameEngine* engine) {
     else if (command.find("addplayer", 0) == 0) {
         engine->addPlayer(command);
     }
-    else if(command=="gamestart"){
+    else if (command == "gamestart") {
         engine->gameStart();
     }
     else if (command == "assigncountries") {
@@ -63,12 +65,12 @@ void ExecuteCommand(string command, GameEngine* engine) {
 }
 
 int testCommandProcessing() {
-    
+
     GameEngine engine("start");
     CommandProcessor processor;
     FileCommandProcessorAdapter fileAdapter("TestCommands/test1.txt", processor);
-    
-    
+
+
     while (true) {
         cout << "1. Read commands from console" << endl;
         cout << "2. Read commands from file" << endl;
@@ -81,41 +83,41 @@ int testCommandProcessing() {
         string s;
 
         switch (choice) {
-            case 1: //enter command by hand
-                while (true) {
-                    s = processor.getCommand();
-                    if(s=="exit"||s=="quit") break;
-                    ExecuteCommand(s, &engine);
-                    //to do: find a better way to save effect
-                    for (Command* cmd : processor.commands) {
-                        if (cmd->commandText.find(s,0)==0) {
-                            cmd->saveEffect(engine.getState());
-                        }
+        case 1: //enter command by hand
+            while (true) {
+                s = processor.getCommand();
+                if (s == "exit" || s == "quit") break;
+                ExecuteCommand(s, &engine);
+                //to do: find a better way to save effect
+                for (Command* cmd : processor.commands) {
+                    if (cmd->commandText.find(s, 0) == 0) {
+                        cmd->saveEffect(engine.getState());
                     }
                 }
-                break;
-            case 2: //read commands from a text file
-                fileAdapter.readCommand();  
-                for (Command* cmd : processor.commands)
-                {
-                    ExecuteCommand(cmd->commandText, &engine);
-                    cmd->saveEffect(engine.getState());
-                }
-                break;
-            case 3:
-                processor.displayCommands();
-                break;
-            case 4:
-                // Clean up memory
-                for (Command* cmd : processor.commands) {
-                    delete cmd;
-                }
-                return 0;
-            default:
-                cout << "Invalid choice. Try again." << endl;
-                break;
+            }
+            break;
+        case 2: //read commands from a text file
+            fileAdapter.readCommand();
+            for (Command* cmd : processor.commands)
+            {
+                ExecuteCommand(cmd->commandText, &engine);
+                cmd->saveEffect(engine.getState());
+            }
+            break;
+        case 3:
+            processor.displayCommands();
+            break;
+        case 4:
+            // Clean up memory
+            for (Command* cmd : processor.commands) {
+                delete cmd;
+            }
+            return 0;
+        default:
+            cout << "Invalid choice. Try again." << endl;
+            break;
         }
-        
+
     }
 }
 

--- a/src/GameEngine.cpp
+++ b/src/GameEngine.cpp
@@ -15,11 +15,13 @@ using namespace std;
 
 class Player;
 
-GameEngine::GameEngine(const string &state) : currentState(state){
+GameEngine::GameEngine(const string& state) :
+    currentState(state)
+{
     currentState = state;
     gameDeck = new Deck(100);
     gameMap = new Map();
-    neutralPlayer  = new Player("neutralPlayer");
+    neutralPlayer = new Player("neutralPlayer");
     _observers = new list<Observer*>;
     this->attach(logObserver);
 }
@@ -37,7 +39,7 @@ GameEngine::~GameEngine() {
     gameDeck = nullptr;
 }
 
-string GameEngine::getState() const{
+string GameEngine::getState() const {
     return currentState;
 }
 
@@ -47,65 +49,68 @@ void GameEngine::setState(string state) {
 
 void GameEngine::loadMap(string command) {
     if (currentState == "start" || currentState == "maploaded") {
-        
+
         int spaceIdx = command.find(' ');
 
         //if spaceIdx is less, than the space either does not exist, or is the last character, so there was no file provided
-        if(spaceIdx < command.length()-1){
+        if (spaceIdx < command.length() - 1) {
             string map = command.substr(spaceIdx + 1);
-            *gameMap = testLoadMap(map); //assignment operator called
+            gameMap = testLoadMap(map); //assignment operator called
             cout << "current state: " << getState() << endl;
             setState("maploaded");
             notify(this);
         }
-        else{
-            cout<<"No map file provided"<<endl;
+        else {
+            cout << "No map file provided" << endl;
         }
-        
-    } else {
+
+    }
+    else {
         cout << "Unable to load state, must be at state 'start' or 'map loaded' to load" << endl;
     }
 }
 
 void GameEngine::validateMap() {
-    
+
     if (getState() == "maploaded") {
-        cout <<"current state: "<< currentState << endl;
+        cout << "current state: " << currentState << endl;
         if (gameMap->validate()) {
             setState("mapvalidated");
             notify(this);
         }
-    } else {
+    }
+    else {
         cout << "Unable to load state, must be at state 'map loaded' to load" << endl;
     }
 }
 
 void GameEngine::addPlayer(string command) {
 
-    if (currentState == "mapvalidated" || currentState == "playersadded" ) {
+    if (currentState == "mapvalidated" || currentState == "playersadded") {
 
-        
+
         int spaceIdx = command.find(' ');
 
         //if spaceIdx is less, than the space either does not exist, or is the last character, so there was no name added
-        if(spaceIdx < command.length()-1){
+        if (spaceIdx < command.length() - 1) {
             //if command is properly called (e.g. "addplayer name"), "addplayer" will be disregarded
-            string name = command.substr(spaceIdx+1);
+            string name = command.substr(spaceIdx + 1);
 
             //stops players from having no name
-                Player* gamer = new Player(name);
-        
-                participants.push_back(gamer);
-                cout <<"current state: "<< currentState << endl;
-                currentState = "playersadded";
+            Player* gamer = new Player(name);
 
-                notify(this);
+            participants.push_back(gamer);
+            cout << "current state: " << currentState << endl;
+            currentState = "playersadded";
+
+            notify(this);
         }
-        else{
-            cout<<"No name provided"<<endl;
+        else {
+            cout << "No name provided" << endl;
 
         }
-    } else {
+    }
+    else {
         cout << "Unable to load state, must be at state 'map validated' or 'players added' to load" << endl;
     }
 }
@@ -115,10 +120,10 @@ void GameEngine::addPlayerObject(Player* player) {
 }
 
 
-void GameEngine::assignCountries(){
-    if (currentState == "playersadded"){
+void GameEngine::assignCountries() {
+    if (currentState == "playersadded") {
         //used to randomize the distribution of territories
-        cout <<"adding countries" << endl;
+        cout << "adding countries" << endl;
         random_device rd;
         mt19937 ran(rd());
 
@@ -130,11 +135,11 @@ void GameEngine::assignCountries(){
         }
 
         //as a vector the elements can be shuffled randomly
-        shuffle(gameTerritories.begin(),gameTerritories.end(),ran);
+        shuffle(gameTerritories.begin(), gameTerritories.end(), ran);
 
-        for(int i =0;i<gameMap->getTerritories().size();i++){
+        for (int i = 0; i < gameMap->getTerritories().size(); i++) {
             //loops through the participants, adding the back territory from the vector to a participant
-            participants[i%participants.size()]->addTerritory(*gameTerritories.back());
+            participants[i % participants.size()]->addTerritory(*gameTerritories.back());
 
             gameTerritories.back()->setOwner(participants[i % participants.size()]);
             //removes the last element to allow access to the next one
@@ -143,22 +148,23 @@ void GameEngine::assignCountries(){
         notify(this);
         //currentState = "assign reinforcement";
         //cout << currentState << endl;
-    } else {
+    }
+    else {
         cout << "Unable to load state, must be at state 'players added' to load" << endl;
     }
 }
 
-void GameEngine::gameStart(){
-    if (currentState == "playersadded"){
+void GameEngine::gameStart() {
+    if (currentState == "playersadded") {
         //4a
         assignCountries();
         //4b
         random_device rd;
         mt19937 ran(rd());
-                    
-        shuffle(participants.begin(),participants.end(),ran);
 
-        for(Player* gamer: participants){
+        shuffle(participants.begin(), participants.end(), ran);
+
+        for (Player* gamer : participants) {
             //4c
             gamer->earnReinforcement(50);
 
@@ -166,75 +172,82 @@ void GameEngine::gameStart(){
 
             gamer->getHand()->addCard(gameDeck->draw());
             gamer->getHand()->addCard(gameDeck->draw());
-            }
-        cout <<"current state: "<< currentState << endl;
+        }
+        cout << "current state: " << currentState << endl;
         currentState = "assignreinforcement";
         notify(this);
-    } else {
-            cout << "Unable to load state, must be at state 'assign reinforcement' or 'issue orders' to load" << endl;
     }
-}
-
-void GameEngine::issueOrder(){
-    if (currentState == "assignreinforcement" || currentState == "issueorders"){
-        setState("issue orders");
-        cout <<"current state: "<< currentState << endl;
-        notify(this);
-    } else {
+    else {
         cout << "Unable to load state, must be at state 'assign reinforcement' or 'issue orders' to load" << endl;
     }
 }
 
-void GameEngine::endIssueOrders(){
+void GameEngine::issueOrder() {
+    if (currentState == "assignreinforcement" || currentState == "issueorders") {
+        setState("issue orders");
+        cout << "current state: " << currentState << endl;
+        notify(this);
+    }
+    else {
+        cout << "Unable to load state, must be at state 'assign reinforcement' or 'issue orders' to load" << endl;
+    }
+}
+
+void GameEngine::endIssueOrders() {
     if (currentState == "issue orders") {
-        cout <<"current state: "<< currentState << endl;
+        cout << "current state: " << currentState << endl;
         setState("execute orders");
         notify(this);
-    } else {
+    }
+    else {
         cout << "Unable to load state, must be at state 'issue orders' to load" << endl;
     }
 }
 
 void GameEngine::execOrder(Orders* order) {
-    if (currentState == "execute orders"){
+    if (currentState == "execute orders") {
         order->execute(this);
         setState("execute orders");
         cout << currentState << endl;
         notify(this);
-    } else {
+    }
+    else {
         cout << "Unable to load state, must be at state 'execute orders' to load" << endl;
     }
 }
 
 void GameEngine::endExecOrders() {
-    if (currentState == "execute orders"){
-        cout <<"current state: "<< currentState << endl;
-        for(Player* player : participants)
+    if (currentState == "execute orders") {
+        cout << "current state: " << currentState << endl;
+        for (Player* player : participants)
         {
+            player->getOrdersList()->clearOrders();
             player->getAlliances().clear();
         }
         currentState = "assign reinforcement";
         notify(this);
-    } else {
+    }
+    else {
         cout << "Unable to load state, must be at state 'execute orders' to load" << endl;
     }
 }
 
 void GameEngine::win() {
-    if (currentState == "execute orders"){
+    if (currentState == "execute orders") {
         currentState = "win";
-        cout <<"current state: "<< currentState << endl;
+        cout << "current state: " << currentState << endl;
         notify(this);
-    } else {
+    }
+    else {
         cout << "Unable to load state, must be at state 'execute orders' to load" << endl;
     }
 }
 
 void GameEngine::end() {
-    if (currentState == "win"){
+    if (currentState == "win") {
         cout << "Game Over. Thanks for playing!" << endl;
 
-        for(Card* card:gameDeck->getDeck()){
+        for (Card* card : gameDeck->getDeck()) {
             delete card;
             card = nullptr;
         }
@@ -242,75 +255,82 @@ void GameEngine::end() {
         gameDeck = nullptr;
         delete gameMap;
         gameMap = nullptr;
-        for(Player* gamer:participants){
-            for(Card* card:gamer->getHand()->getHand()){
+        for (Player* gamer : participants) {
+            for (Card* card : gamer->getHand()->getHand()) {
                 delete card;
                 card = nullptr;
             }
             delete gamer->getHand();
-            
+
             gamer = nullptr;
         }
 
         abort();
-    } else {
+    }
+    else {
         cout << "Unable to load state, must be at state 'win' to load" << endl;
     }
 }
 
 void GameEngine::play() {
-    if (currentState == "win" ||currentState == "start"){
+    if (currentState == "win" || currentState == "start") {
 
         currentState = "start";
-        cout <<"current state: "<< currentState << endl;
+        cout << "current state: " << currentState << endl;
         notify(this);
-    } else {
+    }
+    else {
         cout << "Unable to load state, must be at state 'win' to load" << endl;
     }
 }
 
-void GameEngine::startUpPhase(){
+void GameEngine::startUpPhase() {
 
-    string command ="";
+    string command = "";
 
     bool startingUp = true;
 
     cout << "Welcome! Please enter a command to begin playing!" << endl;
 
-    while(startingUp || (participants.size() < 2)){
+    while (startingUp || (participants.size() < 2)) {
         command = processor.getCommand();
-        if (command.find("loadmap",0)==0){
-            cout<<"Loading Map"<<endl;
+        if (command.find("loadmap", 0) == 0) {
+            cout << "Loading Map" << endl;
             this->loadMap(command);
-        } else if (command == "validatemap") {
-            cout<<"Validating Map"<<endl;
+        }
+        else if (command == "validatemap") {
+            cout << "Validating Map" << endl;
             this->validateMap();
-        } else if (command.find("addplayer",0)==0) {
-            cout<<"Adding Player"<<endl;
-            if(participants.size() < 6){
-                    this->addPlayer(command);
-            }else{
-                cout<<"Maximum number of players reached"<<endl;
+        }
+        else if (command.find("addplayer", 0) == 0) {
+            cout << "Adding Player" << endl;
+            if (participants.size() < 6) {
+                this->addPlayer(command);
             }
-        } else if (command == "gamestart") {
-            if(participants.size()>=2){
-                cout<<"Starting Game"<<endl;
+            else {
+                cout << "Maximum number of players reached" << endl;
+            }
+        }
+        else if (command == "gamestart") {
+            if (participants.size() >= 2) {
+                cout << "Starting Game" << endl;
                 gameStart();
 
                 //4e
                 startingUp = false;
-                
-            }else{
-                cout<<"Not enough players have been added"<<endl;
+
+            }
+            else {
+                cout << "Not enough players have been added" << endl;
             }
         }
-        else{
-            cout<<"Unknown command"<<endl;
+        else {
+            cout << "Unknown command" << endl;
         }
     }
 }
 
-Player* GameEngine::getNeutralPlayer(){
+Player* GameEngine::getNeutralPlayer() {
     return neutralPlayer;
 }
 
@@ -319,16 +339,17 @@ void GameEngine::mainGameLoop() {
     // null player pointer
     // assign to winner
 
-    Player *winningPlayer = nullptr;
-    while(winningPlayer == nullptr){
+    Player* winningPlayer = nullptr;
+    while (winningPlayer == nullptr) {
         reinforcementPhase();
-        cout<<"Reinforments gained"<<endl;
+        cout << "Reinforments gained" << endl;
         issueOrderPhase();
-        cout<<"Orders issued"<<endl;
+        cout << "Orders issued" << endl;
         executeOrdersPhase();
-        cout<<"Executing orders"<<endl;
+        cout << "Executing orders" << endl;
 
         // remove players than have no more territories
+        std::vector<Player*> losers;
         for (const auto& playerPtr : participants) {
             int numOfTerritories = 0;
             for (const auto& thisTerritory : playerPtr->getTerritories()) {
@@ -336,16 +357,32 @@ void GameEngine::mainGameLoop() {
             }
             if (numOfTerritories <= 0) {
                 cout << "Player " << playerPtr->getName() << " has no territories, they have lost!" << endl;
-                delete playerPtr;
+                losers.push_back(playerPtr);
             }
+        }
+
+        for (Player* loser : losers) {
+            participants.erase(std::remove(participants.begin(), participants.end(), loser), participants.end());
+            delete loser;
         }
 
         if (participants.size() == 1) {
             cout << "Player " << participants[0]->getName() << " has won the game!!!" << endl;
             winningPlayer = participants[0];
         }
-        else{
-            cout<<"Next Round!"<<endl;
+        else if (participants.size() == 0) {
+            cout << "EVERYBODY LOST OH NO" << endl;
+            break;
+        }
+        else {
+            for (const auto& playerPtr : participants) {
+                int unitsDeployed = 0;
+                for (const auto& territory : playerPtr->getTerritories()) {
+                    unitsDeployed += territory->getUnits();
+                }
+                cout << "LOL" << endl;
+            }
+            cout << "Next Round!" << endl;
         }
     }
 }
@@ -394,7 +431,7 @@ void GameEngine::issueOrderPhase() {
     // Have each player issue their orders
     setState("issue orders");
     for (const auto& playerPtr : participants) {
-        playerPtr->issueOrder(playerPtr,this);
+        playerPtr->issueOrder(playerPtr, this);
     }
     endIssueOrders();
 }
@@ -403,7 +440,7 @@ void GameEngine::executeOrdersPhase() {
     setState("execute orders");
     for (const auto& playerPtr : participants) {
         OrdersList* list = playerPtr->getOrdersList();
-        for (const auto& orderPtr : list->getOrders()) {
+        for (Orders* orderPtr : list->getOrders()) {
             cout << "executing order" << endl;
             execOrder(orderPtr);
         }
@@ -411,13 +448,13 @@ void GameEngine::executeOrdersPhase() {
     endExecOrders();
 }
 
-Map* GameEngine::getMap(){
+Map* GameEngine::getMap() {
     return gameMap;
 }
-vector<Player*> GameEngine::getPlayers(){
+vector<Player*> GameEngine::getPlayers() {
     return participants;
 }
-Deck* GameEngine::getDeck(){
+Deck* GameEngine::getDeck() {
     return gameDeck;
 }
 

--- a/src/GameEngineDriver.cpp
+++ b/src/GameEngineDriver.cpp
@@ -9,53 +9,64 @@
 
 using namespace std;
 
-void testGameStates(){
+void testGameStates() {
     GameEngine engine("start");
 
     CommandProcessor processor;
-    
+
     string command;
-    bool exit = false;  
+    bool exit = false;
     Map myMap;
 
     cout << "Welcome! Please enter a command to begin playing!" << endl;
 
-    while (exit == false){
+    while (exit == false) {
         command = processor.getCommand();
-        if (command == "loadmap"){
+        if (command == "loadmap") {
             engine.loadMap(command);
-        } else if (command == "validatemap") {
+        }
+        else if (command == "validatemap") {
             engine.validateMap();
-        } else if (command == "addplayer") {
+        }
+        else if (command == "addplayer") {
             engine.addPlayer("");
-        } else if (command == "assigncountries") {
+        }
+        else if (command == "assigncountries") {
             engine.assignCountries();
-        } else if (command == "issueorder") {
+        }
+        else if (command == "issueorder") {
             engine.issueOrder();
-        } else if (command == "endissueorders") {
+        }
+        else if (command == "endissueorders") {
             engine.endIssueOrders();
-        } else if (command == "execorder") {
+        }
+        else if (command == "execorder") {
             //engine.execOrder();
-        } else if (command == "endexecorders") {
+        }
+        else if (command == "endexecorders") {
             engine.endExecOrders();
-        } else if (command == "win") {
+        }
+        else if (command == "win") {
             engine.win();
-        } else if (command == "end") {
+        }
+        else if (command == "end") {
             engine.end();
-        } else if (command == "play") {
+        }
+        else if (command == "play") {
             engine.play();
-        }else if (command == "exit") {
+        }
+        else if (command == "exit") {
             exit = true;
         }
         else {
             cout << "Incorrect command. Please retry." << endl;
-            cout << command<< endl;
+            cout << command << endl;
         }
     }
 }
 
 
-void testStartupPhase(){
+void testStartupPhase() {
     GameEngine engine("execute orders");
     engine.startUpPhase();
 
@@ -70,18 +81,18 @@ void testStartupPhase(){
 
     int playerCount = 1;
 
-    for(Player* player: contestants){
-        cout<<"\nPlayer "<<playerCount++<<endl;
-        cout<<"Name: "<<player->getName()<<endl;
-        cout<<"Territories: ";
-        for(Territory* land: player->getTerritories()){
-            cout<<land->getName()<<" ";
+    for (Player* player : contestants) {
+        cout << "\nPlayer " << playerCount++ << endl;
+        cout << "Name: " << player->getName() << endl;
+        cout << "Territories: ";
+        for (Territory* land : player->getTerritories()) {
+            cout << land->getName() << " ";
         }
-        cout<<"\nHand: ";
-        for(Card* card: player->getHand()->getHand()){
-            cout<<card->getType()->getName()<< " ";
+        cout << "\nHand: ";
+        for (Card* card : player->getHand()->getHand()) {
+            cout << card->getType()->getName() << " ";
         }
-        cout<<"\n";
+        cout << "\n";
 
     }
 
@@ -101,4 +112,3 @@ void testStartupPhase(){
 //    testGameStates();
 //    return 0;
 //}
-

--- a/src/MainDriver.cpp
+++ b/src/MainDriver.cpp
@@ -23,15 +23,16 @@ int main() {
     if (file.is_open()) {
         // Erase the content of the file
         file.close();
-    } else {
+    }
+    else {
         // Handle error if the file cannot be opened
         std::cout << "Error opening the file." << std::endl;
         return 1;
     }
-    
+
     //compile using
     //g++ Orders.cpp cards.cpp Map.cpp Territory.cpp Player.cpp CommandProcessing.cpp GameEngine.cpp MainDriver.cpp -o mainDriver 
-    
+
     //run using ./mainDriver
 
     /*
@@ -59,7 +60,7 @@ int main() {
     testTournament();
 
     testPlayerStrategies();
-    
+
 
     return 0;
 }

--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -137,13 +137,13 @@ void Map::connect(const string& name1, const string& name2) {
 
 void Map::display() const {
 	for (const auto& pair : continents) {
-		cout<<"Continent: " <<pair.second->getName() <<endl;
-		for (const auto& territory : pair.second->getTerritory()){
-			cout<<"\t Territory: "<<territory->getName()<<": ";
+		cout << "Continent: " << pair.second->getName() << endl;
+		for (const auto& territory : pair.second->getTerritory()) {
+			cout << "\t Territory: " << territory->getName() << ": ";
 			for (const auto& adj : territory->getAdjacents()) {
-				cout<< adj->getName()<<", ";
+				cout << adj->getName() << ", ";
 			}
-			cout<<endl;
+			cout << endl;
 		}
 	}
 }
@@ -166,7 +166,7 @@ bool Map::areContinentsSubgraphs() {
 
 bool Map::isMapConnected() {
 	if (territories.empty()) {
-		cout<<"Validation failed: Map is empty.";
+		cout << "Validation failed: Map is empty.";
 		return false;
 	}
 	unordered_set<string> visited;
@@ -192,31 +192,32 @@ vector<Territory*> Map::getTerritoriesVector() {
 
 bool Map::validate() {
 
-/*
-	if (areContinentsSubgraphs()) {
-		cout << "Validated: All Continents are Sub-graphs!\n";
-	}
-	else {
-		cout << "Validation failed: Continents are not sub-graphs of map\n";
-	}
+	/*
+		if (areContinentsSubgraphs()) {
+			cout << "Validated: All Continents are Sub-graphs!\n";
+		}
+		else {
+			cout << "Validation failed: Continents are not sub-graphs of map\n";
+		}
 
-	*/
+		*/
 
-	//disabled , it cause program to exit
-	/*if (isMapConnected()) {
-		cout << "Validated: Map is Connected!\n";
-	}
-	else {
-		cout << "Validation failed: Map is not connected.\n";
-	}*/
-		
+		//disabled , it cause program to exit
+		/*if (isMapConnected()) {
+			cout << "Validated: Map is Connected!\n";
+		}
+		else {
+			cout << "Validation failed: Map is not connected.\n";
+		}*/
+
 	if (/*isMapConnected() && areContinentsSubgraphs()*/ true) {
-		cout<< "Map has been Validated!\n"; 
+		cout << "Map has been Validated!\n";
 		return true;
 	}
-	cout<< "Map is invalid.\n";
+	cout << "Map is invalid.\n";
 	return false;
 
 }
+
 
 

--- a/src/Orders.cpp
+++ b/src/Orders.cpp
@@ -77,7 +77,7 @@ Deploy::Deploy(int unitsIn, Territory* targetIn, Player* issuingPlayerIn) {
     this->units = unitsIn;
     this->target = targetIn;
     this->issuingPlayer = issuingPlayerIn;
-   
+
     setDescription("put a certain number of army units on a target territory");
     setResult("Units have been deployed.");
 }
@@ -87,19 +87,25 @@ string Deploy::getName() {
 }
 
 
-bool Deploy::validate(GameEngine* gameEngine){
-    bool valid = false;
+bool Deploy::validate(GameEngine* gameEngine) {
+    bool valid = true;
     std::cout << "Validating deploy action" << std::endl;
     //if element found, deploy is valid
 //should I be checking reinforcement pool as well?
-    if(((this->issuingPlayer->getName().compare(this->target->getOwner()->getName()))==0) && (this->issuingPlayer->getReinforcement()>= this->units)){
-        valid = true;
-    }
+    std::string issuingName = this->issuingPlayer->getName();
+    std::string ownerName = this->target->getOwner()->getName();
+
+    bool samePlayer = issuingName.compare(ownerName) == 0;
+    valid &= samePlayer;
+
+    int issuingReinforcementCount = this->issuingPlayer->getReinforcement();
+    bool hasEnoughUnits = issuingReinforcementCount >= this->units;
+    valid &= hasEnoughUnits;
 
     return valid;
 }
 
-void Deploy::execute(GameEngine* gameEngine){
+void Deploy::execute(GameEngine* gameEngine) {
     if (validate(gameEngine)) {
         this->target->setUnits(this->target->getUnits() + this->units);
         this->issuingPlayer->useReinforcement(this->units);
@@ -119,7 +125,7 @@ Advance::Advance(int unitsIn, Territory* sourceIn, Territory* targetIn, Player* 
     setResult("Units have been moved.");
     this->source = sourceIn;
     this->target = targetIn;
-    
+
     units = unitsIn;
     this->issuingPlayer = issuingPlayerIn;
 }
@@ -128,19 +134,19 @@ string Advance::getName() {
     return "Advance";
 }
 
-bool Advance::validate(GameEngine* gameEngine){
+bool Advance::validate(GameEngine* gameEngine) {
     std::cout << "Validating advance action" << std::endl;
     bool valid = false;
     //source not owned by issuer OR target not adjacent
     Territory* p = *find(this->source->getAdjacents().begin(), this->source->getAdjacents().end(), this->target);
-    if ((this->source->getOwner()->getName().compare(this->issuingPlayer->getName()) == 0) || (p!= *this->source->getAdjacents().end())) {
+    if ((this->source->getOwner()->getName().compare(this->issuingPlayer->getName()) == 0) || (p != *this->source->getAdjacents().end())) {
         valid = true;
     }
     return valid;
 }
 
-void Advance::execute(GameEngine* gameEngine){
- 
+void Advance::execute(GameEngine* gameEngine) {
+
     if (validate(gameEngine)) {
         if ((this->target->getOwner()->getName().compare(this->issuingPlayer->getName())) == 0) {
             this->target->setUnits(this->target->getUnits() + this->units);
@@ -149,12 +155,12 @@ void Advance::execute(GameEngine* gameEngine){
             notify(this);
         }
     }
-    else if(validate(gameEngine) && !isAlly(source->getOwner(), target->getOwner())){
-            Battle(this->source, this->target, this->issuingPlayer);
-            std::cout << getResult() << std::endl;
-            notify(this);
-        }
-        
+    else if (validate(gameEngine) && !isAlly(source->getOwner(), target->getOwner())) {
+        Battle(this->source, this->target, this->issuingPlayer);
+        std::cout << getResult() << std::endl;
+        notify(this);
+    }
+
     else {
         std::cout << "Could not move army units." << std::endl;
     }
@@ -162,9 +168,9 @@ void Advance::execute(GameEngine* gameEngine){
 
 bool Advance::isAlly(Player* player1, Player* player2) {
     bool isAlly = false;
- 
-    for (Player * players1 : player1->getAlliances()) {
-        for (Player * players2 : player2->getAlliances()) {
+
+    for (Player* players1 : player1->getAlliances()) {
+        for (Player* players2 : player2->getAlliances()) {
             if (players1->getName().compare(players2->getName()) == 0) {
                 isAlly = true;
             }
@@ -181,7 +187,7 @@ void Advance::Battle(Territory* source, Territory* target, Player* issuingPlayer
             target->setUnits((target->getUnits()) - 1);
         }
         if (rand() % 100 + 1 <= 70) {
-            source->setUnits((source->getUnits())-1);
+            source->setUnits((source->getUnits()) - 1);
         }
     }
     if (target->getUnits() == 0) {
@@ -190,8 +196,8 @@ void Advance::Battle(Territory* source, Territory* target, Player* issuingPlayer
         this->issuingPlayer->addTerritory(*target);
         target->setUnits(source->getUnits());
         source->setUnits(0);
-            //remove?
-       // this->issuingPlayer->getHand()->addCard(Deck::draw());
+        //remove?
+   // this->issuingPlayer->getHand()->addCard(Deck::draw());
     }
 }
 
@@ -209,7 +215,7 @@ string Bomb::getName() {
     return "Bomb";
 }
 
-bool Bomb::validate(GameEngine* gameEngine){
+bool Bomb::validate(GameEngine* gameEngine) {
     bool valid = false;
     bool isAdjacent = false;
     bool isAlly = false;
@@ -233,14 +239,14 @@ bool Bomb::validate(GameEngine* gameEngine){
         }
     }
     std::cout << "Validating bomb action" << std::endl;
-    if (((this->target->getOwner()->getName().compare(this->issuingPlayer->getName()))!=0) && isAdjacent && !isAlly && hasCard) {
+    if (((this->target->getOwner()->getName().compare(this->issuingPlayer->getName())) != 0) && isAdjacent && !isAlly && hasCard) {
         valid = true;
     }
-    
+
     return valid;
 }
 
-void Bomb::execute(GameEngine* gameEngine){
+void Bomb::execute(GameEngine* gameEngine) {
     if (validate(gameEngine)) {
         std::cout << getResult() << std::endl;
         this->target->setUnits((this->target->getUnits()) / 2);
@@ -264,7 +270,7 @@ string Blockade::getName() {
     return "Blockade";
 }
 
-bool Blockade::validate(GameEngine* gameEngine){
+bool Blockade::validate(GameEngine* gameEngine) {
     bool valid = false;
     bool hasCard = false;
     for (Card* card : this->issuingPlayer->getHand()->getHand()) {
@@ -272,7 +278,7 @@ bool Blockade::validate(GameEngine* gameEngine){
             hasCard = true;
         }
     }
-    if (((this->target->getOwner()->getName().compare(this->issuingPlayer->getName())) == 0) && hasCard){
+    if (((this->target->getOwner()->getName().compare(this->issuingPlayer->getName())) == 0) && hasCard) {
         valid = true;
     }
     std::cout << "Validating blockade action" << std::endl;
@@ -308,7 +314,7 @@ string Airlift::getName() {
     return "Airlift";
 }
 
-bool Airlift::validate(GameEngine* gameEngine){
+bool Airlift::validate(GameEngine* gameEngine) {
     bool valid = false;
     bool hasCard = false;
     std::cout << "Validating airlift action" << std::endl;
@@ -318,13 +324,13 @@ bool Airlift::validate(GameEngine* gameEngine){
         }
     }
     //target and source territories have same owner
-    if ((this->source->getOwner()->getName().compare(this->target->getOwner()->getName()))==0 && hasCard) {
+    if ((this->source->getOwner()->getName().compare(this->target->getOwner()->getName())) == 0 && hasCard) {
         valid = true;
     }
     return valid;
 }
 
-void Airlift::execute(GameEngine* gameEngine){
+void Airlift::execute(GameEngine* gameEngine) {
     if (validate(gameEngine)) {
         std::cout << getResult() << std::endl;
         this->target->setUnits(this->target->getUnits() + this->units);
@@ -361,7 +367,7 @@ bool Negotiate::validate(GameEngine* gameEngine) {
         valid = true;
     }
     std::cout << "Validating negotiate action" << std::endl;
-    
+
     return valid;
 }
 
@@ -432,6 +438,10 @@ void OrdersList::printOrders()
 
 vector<Orders*> OrdersList::getOrders() {
     return ordersList;
+}
+
+void OrdersList::clearOrders() {
+    ordersList.clear();
 }
 
 //Log method

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -3,7 +3,7 @@
 *   definitions of the object Player as well as its attributes.
 *
 *   Written by: Mark Kandaleft
-*   For COMP 345 
+*   For COMP 345
 */
 
 #include "../include/Player.h"
@@ -25,18 +25,18 @@ using std::cout;
 using std::string;
 using std::vector;
 
-Player::Player(const string& playerName) : name(playerName),reinforcementPool(0){
-    hand = new Hand(10,this);
+Player::Player(const string& playerName) : name(playerName), reinforcementPool(0) {
+    hand = new Hand(10, this);
     beenAttacked = false;
     strat = new Neutral();
     ordersList = new OrdersList();
 }
 
-Player::Player(const string& playerName, PlayerStrategy* plan) : name(playerName),reinforcementPool(0){
+Player::Player(const string& playerName, PlayerStrategy* plan) : name(playerName), reinforcementPool(0) {
     hand = new Hand();
     beenAttacked = false;
     strat = plan;
-        ordersList = new OrdersList();
+    ordersList = new OrdersList();
 }
 
 Player::~Player() {
@@ -57,18 +57,18 @@ void Player::addTerritory(Territory& territory) {
 }
 
 // Returns a list of territories to be defended
-const vector<Territory*> Player::toDefend(){
+const vector<Territory*> Player::toDefend() {
     return strat->toDefend(this);
 }
 
 // Returns a list of territories to be attacked
-const vector<Territory*> Player::toAttack(){
+const vector<Territory*> Player::toAttack() {
     return strat->toAttack(this);
 }
 
 // Creates an order object and adds it to the list of orders
-void Player::issueOrder(Player* player, GameEngine* engine){
-    strat->issueOrder(this,engine);
+void Player::issueOrder(Player* player, GameEngine* engine) {
+    strat->issueOrder(this, engine);
 }
 
 string Player::getName() const {
@@ -93,19 +93,19 @@ void Player::setName(const string& newName) {
     name = newName;
 }
 
-void Player::earnReinforcement(int add){
-    reinforcementPool+= add;
+void Player::earnReinforcement(int add) {
+    reinforcementPool += add;
 }
 
-void Player::useReinforcement(int use){
-    reinforcementPool-= use;
+void Player::useReinforcement(int use) {
+    reinforcementPool -= use;
 }
 
-int Player::getPoolSize(){
+int Player::getPoolSize() {
     return reinforcementPool;
 }
 
-OrdersList* Player::getOrdersList(){
+OrdersList* Player::getOrdersList() {
     return ordersList;
 }
 
@@ -113,7 +113,7 @@ vector<Territory*> Player::getTerritories() const {
     return territories;
 }
 
-Hand* Player::getHand(){
+Hand* Player::getHand() {
     return hand;
 }
 
@@ -128,24 +128,24 @@ void Player::addAlliance(Player* ally)
 }
 
 //Gets all territories not owned by me, that are touching a territory owned by me
-vector<Territory*> Player::getSurroundings(){
-    
+vector<Territory*> Player::getSurroundings() {
+
     vector<Territory*> surroundings;
     vector<Territory*> nextToMe;
 
     //check all owned territories
-    for(Territory* ownedTerr:getTerritories()){
+    for (Territory* ownedTerr : getTerritories()) {
 
         //check all adjacent territories of owned territories
         nextToMe = ownedTerr->getAdjacents();
-        for(Territory* adj:nextToMe){
+        for (Territory* adj : nextToMe) {
             auto it = find(nextToMe.begin(), nextToMe.end(), adj);
 
             //if the adjacent territory was already added, or its owned by this player, don't add
-            if(it != nextToMe.end() || adj->getOwner() == this){
+            if (it != nextToMe.end() || adj->getOwner() == this) {
                 continue;
             }
-            else{
+            else {
                 surroundings.push_back(adj);
             }
         }
@@ -155,18 +155,18 @@ vector<Territory*> Player::getSurroundings(){
     return surroundings;
 }
 
-void Player::setBeenAttacked(bool status){
+void Player::setBeenAttacked(bool status) {
     beenAttacked = status;
 }
 
-bool Player::getBeenAttacked(){
+bool Player::getBeenAttacked() {
     return beenAttacked;
 }
 
-void Player::setStrategy(PlayerStrategy* plan){
+void Player::setStrategy(PlayerStrategy* plan) {
 
     //reset so neutral player doesn't immediately become aggressive
-    if(typeid(plan) == typeid(Neutral))
+    if (typeid(plan) == typeid(Neutral))
         beenAttacked = false;
 
     strat = plan;

--- a/src/PlayerDriver.cpp
+++ b/src/PlayerDriver.cpp
@@ -3,7 +3,7 @@
 *   for testing the functionalities of a Player object.
 *
 *   Written by: Mark Kandaleft
-*   For COMP 345 
+*   For COMP 345
 */
 #include "iostream"
 #include <vector>
@@ -40,3 +40,4 @@ void testPlayers() {
     std::cout << std::endl;
 
 }
+

--- a/src/PlayerStrategies.cpp
+++ b/src/PlayerStrategies.cpp
@@ -3,6 +3,8 @@
 #include <random>
 #include <sstream>
 #include <typeinfo>
+#include <unordered_set>
+#include <stack>
 
 #include "../include/PlayerStrategies.h"
 #include "../include/cards.h"
@@ -13,11 +15,11 @@ using namespace std;
 
 /*
 requires user interactions to make decisions, including deploy and advance orders, as well as
-playing any card. 
+playing any card.
 */
-void Human::issueOrder(Player* person, GameEngine* theGame){
-    cout<<"Am human"<<endl;
-     // Make the player decide which territories they want to attack/defend
+void Human::issueOrder(Player* person, GameEngine* theGame) {
+    cout << "Am human" << endl;
+    // Make the player decide which territories they want to attack/defend
     const vector<Territory*>& toAttackResult = person->toAttack();
     const vector<Territory*>& toDefendResult = person->toDefend();
 
@@ -27,7 +29,7 @@ void Human::issueOrder(Player* person, GameEngine* theGame){
     // Add deploy orders while reinforcement pool isn't empty
     cout << "You will now choose which territories you'd like to Deploy troops to." << endl;
     while (reinforcementRef > 0) {
-        for (const auto& thisDefendable : toDefendResult){
+        for (const auto& thisDefendable : toDefendResult) {
             // put number of units
             cout << "How many armies would you like to send to " << thisDefendable->getName() << "? (enter an integer)" << endl;
             int armiesToSend = 0;
@@ -38,9 +40,9 @@ void Human::issueOrder(Player* person, GameEngine* theGame){
             reinforcementRef -= armiesToSend;
         }
     }
-    
+
     // Issue Advance orders to attack
-    for (const auto& thisAttackable : toAttackResult){
+    for (const auto& thisAttackable : toAttackResult) {
         cout << "How many armies would you like to send to attack " << thisAttackable->getName() << "? (enter an integer)" << endl;
         int armiesToSend = 0;
         cin >> armiesToSend;
@@ -59,131 +61,132 @@ void Human::issueOrder(Player* person, GameEngine* theGame){
 
     // allow player to play cards
     // if has cards to play, ask player, otherwise dont ask
-    if (person->getHand()->getSize() != 0){
+    if (person->getHand()->getSize() != 0) {
         cout << "Decide which card you would like to play." << endl;
-        cout<<"Enter the order command you would like to make (corresponding integer to the command):"<<endl;
-        cout<<"1. Bomb"<<endl;
-        cout<<"2. Blockade"<<endl;
-        cout<<"3. Airlift"<<endl;
-        cout<<"4. Negotiate"<<endl;
-        cout<<"5. I don't want to play a card."<<endl;
+        cout << "Enter the order command you would like to make (corresponding integer to the command):" << endl;
+        cout << "1. Bomb" << endl;
+        cout << "2. Blockade" << endl;
+        cout << "3. Airlift" << endl;
+        cout << "4. Negotiate" << endl;
+        cout << "5. I don't want to play a card." << endl;
         int cardSelect = 0;
         std::cin >> cardSelect;
         // validate the selection from the player
-        while (cardSelect < 1 || cardSelect > 5){
-            cout<<"Invalid order command. Please enter a valid command."<<endl;
+        while (cardSelect < 1 || cardSelect > 5) {
+            cout << "Invalid order command. Please enter a valid command." << endl;
             std::cin >> cardSelect;
         }
         vector<Player*> players = theGame->getPlayers();
-        switch(cardSelect){
+        switch (cardSelect) {
             // Play a bomb card. Prompt player to choose the adjacent territory to bomb
-            case 1: {
-                cout<<"You've chosen to play a Bomb card."<<endl;
-                cout<<"Enter an enemy territory adjacent to yours to bomb:";
-                string bombTerritory = "";
-                cin >> bombTerritory;
-                bool found = false;
-                for (const auto& targetPlayer : theGame->getPlayers()) {
-                    for (const auto& targetTerritory : targetPlayer->getTerritories()) {
-                        if (targetTerritory->getName() == bombTerritory) {
-                            Bomb newBomb(targetTerritory, person);
-                            Bomb* bombPtr = &newBomb;
-                            person->getOrdersList()->addOrder(bombPtr);
-                            found = true;
-                            break;
-                        }
-                    }
-                    if (found) break;
-                }
-                break; } 
-            case 2: {
-                // Play a blockade card. Prompt player for which territory they want to blockade on.
-                cout<<"You've chosen to play a Blockade card."<<endl;
-                cout << "Here are the territories available: " << endl;
-                for (const auto& thisTerritory : person->getTerritories()){
-                    cout << thisTerritory->getName();
-                }
-                cout << endl;
-                cout <<"Enter the territory you'd like to blockade: ";
-                string blockadeThis = "";
-                for (const auto& targetTerritory : person->getTerritories()) {
-                    if (targetTerritory->getName() == blockadeThis){
-                        Blockade newBlockade(targetTerritory, person);
-                        Blockade* blockadePtr = &newBlockade;
-                        person->getOrdersList()->addOrder(blockadePtr);
+        case 1: {
+            cout << "You've chosen to play a Bomb card." << endl;
+            cout << "Enter an enemy territory adjacent to yours to bomb:";
+            string bombTerritory = "";
+            cin >> bombTerritory;
+            bool found = false;
+            for (const auto& targetPlayer : theGame->getPlayers()) {
+                for (const auto& targetTerritory : targetPlayer->getTerritories()) {
+                    if (targetTerritory->getName() == bombTerritory) {
+                        Bomb newBomb(targetTerritory, person);
+                        Bomb* bombPtr = &newBomb;
+                        person->getOrdersList()->addOrder(bombPtr);
+                        found = true;
                         break;
                     }
                 }
-                break; }
-            case 3: {
-                // Play an airlift card. Prompt player to enter where to airlift from, the amount of troops to airlift, and where to airlift to.
-                cout<<"You've chosen to play an Airlift card."<<endl;
-                // find the territory to airlift from
-                cout << "Decide which territory to airlift to " << endl;
-                cout << "Here are the territories available: " << endl;
-                for (const auto& thisTerritory : person->getTerritories()){
-                    cout << thisTerritory->getName();
+                if (found) break;
+            }
+            break; }
+        case 2: {
+            // Play a blockade card. Prompt player for which territory they want to blockade on.
+            cout << "You've chosen to play a Blockade card." << endl;
+            cout << "Here are the territories available: " << endl;
+            for (const auto& thisTerritory : person->getTerritories()) {
+                cout << thisTerritory->getName();
+            }
+            cout << endl;
+            cout << "Enter the territory you'd like to blockade: ";
+            string blockadeThis = "";
+            for (const auto& targetTerritory : person->getTerritories()) {
+                if (targetTerritory->getName() == blockadeThis) {
+                    Blockade newBlockade(targetTerritory, person);
+                    Blockade* blockadePtr = &newBlockade;
+                    person->getOrdersList()->addOrder(blockadePtr);
+                    break;
                 }
-                cout << endl;
-                cout << "Enter the territory you want to airlift from: ";
-                string stringFrom = "";
-                cin >> stringFrom;
-                cout << endl;
-                cout << "Enter the territory you want to airlift to: ";
-                string stringTo = "";
-                cin >> stringTo;
-                cout << endl;
-                cout << "Enter the amount of units to airlift: ";
-                int unitsToAirlift = 0;
-                cin >> unitsToAirlift;
-                cout << endl;
-                Territory* fromPtr;
-                Territory* toPtr;
-                for (const auto& targetTerritory : person->getTerritories()) {
-                    if (targetTerritory->getName() == stringFrom) fromPtr = targetTerritory;
-                    else if (targetTerritory->getName() == stringTo) toPtr = targetTerritory;
-                }
-                Airlift newAirlift(unitsToAirlift, fromPtr, toPtr, person);
-                Airlift* airliftPtr = &newAirlift;
-                person->getOrdersList()->addOrder(airliftPtr);
-                break; }
-            case 4: {
-                // Play a negotiate card. Prompt the player to choose another player to target for negotiation.
-                cout<<"You've chosen to play a Negotiate card."<<endl;
-                // pick a player to target
-                cout<<"Enter the name of the player you'd like to Negotiate: ";
-                string playerName = "";
-                cin >> playerName;
-                // search for corresponding player
-                for (const auto& targetPlayer : players) {
-                    if (typeid(targetPlayer) != typeid(this)) {
-                        if (targetPlayer->getName() == playerName) {
-                            Negotiate newNegotiate(targetPlayer, person);
-                            Negotiate* negotiatePtr = &newNegotiate;
-                            person->getOrdersList()->addOrder(negotiatePtr);
-                            break;
-                        }
+            }
+            break; }
+        case 3: {
+            // Play an airlift card. Prompt player to enter where to airlift from, the amount of troops to airlift, and where to airlift to.
+            cout << "You've chosen to play an Airlift card." << endl;
+            // find the territory to airlift from
+            cout << "Decide which territory to airlift to " << endl;
+            cout << "Here are the territories available: " << endl;
+            for (const auto& thisTerritory : person->getTerritories()) {
+                cout << thisTerritory->getName();
+            }
+            cout << endl;
+            cout << "Enter the territory you want to airlift from: ";
+            string stringFrom = "";
+            cin >> stringFrom;
+            cout << endl;
+            cout << "Enter the territory you want to airlift to: ";
+            string stringTo = "";
+            cin >> stringTo;
+            cout << endl;
+            cout << "Enter the amount of units to airlift: ";
+            int unitsToAirlift = 0;
+            cin >> unitsToAirlift;
+            cout << endl;
+            Territory* fromPtr = nullptr;
+            Territory* toPtr = nullptr;
+            for (const auto& targetTerritory : person->getTerritories()) {
+                if (targetTerritory->getName() == stringFrom) fromPtr = targetTerritory;
+                else if (targetTerritory->getName() == stringTo) toPtr = targetTerritory;
+            }
+            Airlift newAirlift(unitsToAirlift, fromPtr, toPtr, person);
+            Airlift* airliftPtr = &newAirlift;
+            person->getOrdersList()->addOrder(airliftPtr);
+            break; }
+        case 4: {
+            // Play a negotiate card. Prompt the player to choose another player to target for negotiation.
+            cout << "You've chosen to play a Negotiate card." << endl;
+            // pick a player to target
+            cout << "Enter the name of the player you'd like to Negotiate: ";
+            string playerName = "";
+            cin >> playerName;
+            // search for corresponding player
+            for (const auto& targetPlayer : players) {
+                if (typeid(targetPlayer) != typeid(this)) {
+                    if (targetPlayer->getName() == playerName) {
+                        Negotiate newNegotiate(targetPlayer, person);
+                        Negotiate* negotiatePtr = &newNegotiate;
+                        person->getOrdersList()->addOrder(negotiatePtr);
+                        break;
                     }
                 }
-                break; }
-            case 5:
-                cout << person->getName() << " has chosen to not play a card." << endl;
-                break;
             }
-    } else { cout << person->getName() << " has no cards to play." << endl; }
+            break; }
+        case 5:
+            cout << person->getName() << " has chosen to not play a card." << endl;
+            break;
+        }
+    }
+    else { cout << person->getName() << " has no cards to play." << endl; }
     cout << person->getName() << " has finished issuing orders." << endl;
 }
 
-vector<Territory*> Human::toAttack(Player* person){
+vector<Territory*> Human::toAttack(Player* person) {
     vector<Territory*> attacking;
 
     vector<Territory*> enemies = person->getSurroundings();
 
-    cout<< "These are your neighbouring territories."<<endl;
-    for(Territory* bad:enemies){
-        cout<<bad->getName()<<" ";
+    cout << "These are your neighbouring territories." << endl;
+    for (Territory* bad : enemies) {
+        cout << bad->getName() << " ";
     }
-    cout<<endl;
+    cout << endl;
 
     // asking player what territories they want to attack
     cout << "Decide which neighbouring territories to attack in priority." << endl;
@@ -199,8 +202,8 @@ vector<Territory*> Human::toAttack(Player* person){
         elements.push_back(element);
     }
     // check for matching name
-    for (const auto& thisElement : elements){
-        for (const auto& thisTerritory : person->getTerritories()){
+    for (const auto& thisElement : elements) {
+        for (const auto& thisTerritory : person->getTerritories()) {
             vector<Territory*> adjacents = thisTerritory->getAdjacents();
             for (const auto& thisAdjacent : adjacents) {
                 if (thisAdjacent->getName() == thisElement) attacking.push_back(thisAdjacent);
@@ -210,14 +213,14 @@ vector<Territory*> Human::toAttack(Player* person){
     return attacking;
 }
 
-vector<Territory*> Human::toDefend(Player* person){
-     vector<Territory*> defending;
+vector<Territory*> Human::toDefend(Player* person) {
+    vector<Territory*> defending;
     int armyCounter;
     // ask how many armies they want to deploy to
     // asking player what territories they want to defend
     cout << "Decide which neighbouring territories to defend in priority." << endl;
     cout << "Here are the territories you can defend: " << endl;
-    for (const auto& thisTerritory : person->getTerritories()){
+    for (const auto& thisTerritory : person->getTerritories()) {
         cout << thisTerritory->getName() << " ";
     }
     cout << endl;
@@ -232,8 +235,8 @@ vector<Territory*> Human::toDefend(Player* person){
         elements.push_back(element);
     }
     // check for matching name
-    for (const auto& thisElement : elements){
-        for (const auto& thisTerritory : person->getTerritories()){
+    for (const auto& thisElement : elements) {
+        for (const auto& thisTerritory : person->getTerritories()) {
             if (thisTerritory->getName() == thisElement) defending.push_back(thisTerritory);
         }
     }
@@ -245,127 +248,117 @@ vector<Territory*> Human::toDefend(Player* person){
 /*
 computer player that focuses on attack (deploys or advances armies on its strongest
 country, then always advances to enemy territories until it cannot do so anymore; will use any card with an
-aggressive purpose, as defined above). 
+aggressive purpose, as defined above).
 */
-void Aggressive::issueOrder(Player* aggressor,GameEngine* theGame){
+void Aggressive::issueOrder(Player* aggressor, GameEngine* theGame) {
 
-/*
-    //CARDS PHASE
+    /*
+        //CARDS PHASE
 
-    //check player hand for aggressive cards
-    vector<Card*> myHand = aggressor->getHand()->getHand();
+        //check player hand for aggressive cards
+        vector<Card*> myHand = aggressor->getHand()->getHand();
 
-    vector<Tarritory*> victims = aggressor->getSurroundings();
+        vector<Tarritory*> victims = aggressor->getSurroundings();
 
-    for(Card* card:myHand){
-        if(typeid(card->getType()) == typeid(Bomb)){
-            card->play(*theGame->getDeck(),*aggressor->getHand()); //play no longer executes it, just removes it from hand and adds to deck
+        for(Card* card:myHand){
+            if(typeid(card->getType()) == typeid(Bomb)){
+                card->play(*theGame->getDeck(),*aggressor->getHand()); //play no longer executes it, just removes it from hand and adds to deck
 
-            for(Territory* land: targets){
-                Bomb kaboom(land,aggressor);
-                Bomb* kaboomPtr = &kaboom;
-                aggressor->getOrderslist()->addOrder(kaboomPtr);
+                for(Territory* land: targets){
+                    Bomb kaboom(land,aggressor);
+                    Bomb* kaboomPtr = &kaboom;
+                    aggressor->getOrderslist()->addOrder(kaboomPtr);
+                }
+
             }
-
         }
-    }
-    */
+        */
 
-   
 
-    //DEFENSE PHASE
 
-    //only one territory is being deployed on
+        //DEFENSE PHASE
+
+        //only one territory is being deployed on
     Territory* champion = aggressor->toDefend().back();
 
     int dropIn = aggressor->getPoolSize();
 
     //deploys all units to strongest territory
-    Deploy dep(dropIn,champion,aggressor);
+    Deploy dep(dropIn, champion, aggressor);
     Deploy* depPtr = &dep;
     aggressor->getOrdersList()->addOrder(depPtr);
 
-    //remove units from pool
-    aggressor->useReinforcement(dropIn);
-
     //ATTACK PHASE
     vector<Territory*> attackThem = aggressor->toAttack();
-    
-    for(Territory* targets: attackThem){
-        Advance attack(champion->getUnits(),champion,targets,aggressor);
+
+    for (Territory* targets : attackThem) {
+        Advance attack(champion->getUnits(), champion, targets, aggressor);
         Advance* atkPtr = &attack;
 
-        
+
         //if aggresssor loses early, you'll get a bunch of unable to move messages when executing
         aggressor->getOrdersList()->addOrder(atkPtr);
 
 
-        if(targets->getOwner() == aggressor){
-            cout<< aggressor->getName() << "'s " << champion->getName() <<" has won against" << targets->getName()<<endl;
+        if (targets->getOwner() == aggressor) {
+            cout << aggressor->getName() << "'s " << champion->getName() << " has won against" << targets->getName() << endl;
         }
-        else{
-            cout<< aggressor->getName() << "'s " << champion->getName() <<" has lost against" << targets->getName()<<endl;
+        else {
+            cout << aggressor->getName() << "'s " << champion->getName() << " has lost against" << targets->getName() << endl;
             break;
         }
     }
 
 }
 
-vector<Territory*> Aggressive::toAttack(Player* aggressor){
-        vector<Territory*> attacking;
-        vector<Territory*> aroundMe;
+vector<Territory*> Aggressive::toAttack(Player* aggressor) {
+    vector<Territory*> aroundMe;
 
-        Territory* strongest = (aggressor->toDefend()).back();
+    Territory* strongest = (aggressor->toDefend()).back();
 
-        //using the name instead of the pointer to avoid issues checking
-        string oldStrongest = strongest->getName();
+    //using the name instead of the pointer to avoid issues checking
+    string oldStrongestName = strongest->getName();
 
-        bool keepFighting = true;
-        int iterations = 0;
+    bool keepFighting = true;
+    int iterations = 0;
 
-        while(keepFighting){
-        //refresh the territories surrounding the strongest after each (presumingly) successful attack
-            aroundMe = strongest->getAdjacents();
+    unordered_set<Territory*> visited;
+    stack<Territory*> toVisit;
 
-            for(Territory* targets:aroundMe){
-                //if its an enemy territory
-                if(targets->getOwner() != aggressor){
-                    attacking.push_back(targets);
+    unordered_set<Territory*> toAttack;
 
-                    //assuming you win the fight you'd end up here
-                    strongest = targets;
-                }
+    toVisit.push(strongest);
+
+    // depth first search to attack every connected neighbor
+    while (!toVisit.empty()) {
+        Territory* current = toVisit.top();
+        toVisit.pop();
+        for (Territory* neighbour : current->getAdjacents()) {
+            toAttack.insert(neighbour);
+            if (visited.find(neighbour) == visited.end()) {
+                visited.insert(neighbour);
+                toVisit.push(neighbour);
             }
-
-            //if the old strongest is the same as the current strongest, no enemy territories were found around it, stop fighting
-            if(oldStrongest == strongest->getName()){
-                keepFighting = false;
-                //just to be sure that it leaves loop
-                break;
-            }
-
-            
-            oldStrongest = strongest->getName();
         }
+    }
 
-        return attacking;
-
+    return vector<Territory*>(toAttack.begin(), toAttack.end());
 }
 
-vector<Territory*> Aggressive::toDefend(Player* aggressor){
+vector<Territory*> Aggressive::toDefend(Player* aggressor) {
     vector<Territory*> defending;
 
     Territory* strongest = nullptr;
     vector<Territory*> myLand = aggressor->getTerritories();
 
     int armyCount;
-    int most = 0;
+    int most = -1;
 
-     //find territory with highest count
-    for(Territory* eachTerr: myLand){
+    //find territory with highest count
+    for (Territory* eachTerr : myLand) {
         armyCount = eachTerr->getUnits();
 
-        if(armyCount > most){
+        if (armyCount > most) {
             most = armyCount;
             strongest = eachTerr;
         }
@@ -373,16 +366,16 @@ vector<Territory*> Aggressive::toDefend(Player* aggressor){
 
 
     defending.push_back(strongest);
-    
+
     return defending;
 }
 
 /*
 computer player that focuses on protecting its weak countries (deploys or advances armies
 on its weakest countries, never advances to enemy territories; may use cards but will never use a card in a way
-that purposefully will harm anyone). 
+that purposefully will harm anyone).
 */
-void Benevolent::issueOrder(Player* peaceKeeper,GameEngine* theGame){
+void Benevolent::issueOrder(Player* peaceKeeper, GameEngine* theGame) {
 
 
     //CARDS PHASE
@@ -413,7 +406,7 @@ void Benevolent::issueOrder(Player* peaceKeeper,GameEngine* theGame){
                 card->play(*theGame->getDeck(),*peaceKeeper->getHand());
 
             }
-        } 
+        }
         else if(typeid(card->getType()) == typeid(Negotiate)){
             //50% chance to play the card
             if (playCard) {
@@ -466,54 +459,55 @@ void Benevolent::issueOrder(Player* peaceKeeper,GameEngine* theGame){
 
     size_t size = defendUs.size();
     int* deploymentDistribution = new int[size];
+    for (int i = 0; i < size; i++) deploymentDistribution[i] = 0;
 
     //evenly distributes across owned territories, while they are left in the pool
-    while(peaceKeeper->getPoolSize() > 0){
-        //keeps track of how many territories actually earn troops, incase there are more weak territories than, troops available
-        numLandDeployedOn++;
-        deploymentDistribution[(index++)%defendUs.size()] += 1;
-        peaceKeeper->useReinforcement(1);
+    if (defendUs.size() > 0) {
+        int unitsAvailable = peaceKeeper->getPoolSize();
+        while (unitsAvailable > 0) {
+            //keeps track of how many territories actually earn troops, incase there are more weak territories than, troops available
+            numLandDeployedOn++;
+            deploymentDistribution[(index++) % defendUs.size()] += 1;
+            unitsAvailable--;
+        }
     }
 
     //if there are enough troops that each territory gets at least one, caps out numLandDeployedOn
-    if(numLandDeployedOn > size)
+    if (numLandDeployedOn > size)
         numLandDeployedOn = size;
 
-        for(int i=0;i<numLandDeployedOn;i++){
-                //neither work, vector push_back doesn't seem to work inside addOrder()
-                
-                /*
-                Deploy* dep = new Deploy(deploymentDistribution[i],defendUs[i],peaceKeeper);
-                peaceKeeper->getOrdersList()->addOrder(dep);
-                */
-               /*
-                Deploy* newNegotiate = new Deploy(deploymentDistribution[i],defendUs[i],peaceKeeper);
-                peaceKeeper->getOrdersList()->addOrder(newNegotiate);
-                */
-                
-            
-                Deploy dep(deploymentDistribution[i],defendUs[i],peaceKeeper);
-                Deploy* depPtr = &dep;
-                peaceKeeper->getOrdersList()->addOrder(depPtr);
-                
-               
-        }
-    
+    for (int i = 0; i < numLandDeployedOn; i++) {
+        //neither work, vector push_back doesn't seem to work inside addOrder()
+
+        /*
+        Deploy* dep = new Deploy(deploymentDistribution[i],defendUs[i],peaceKeeper);
+        peaceKeeper->getOrdersList()->addOrder(dep);
+        */
+        /*
+         Deploy* newNegotiate = new Deploy(deploymentDistribution[i],defendUs[i],peaceKeeper);
+         peaceKeeper->getOrdersList()->addOrder(newNegotiate);
+         */
+
+
+        Deploy* depPtr = new Deploy(deploymentDistribution[i], defendUs[i], peaceKeeper);
+        peaceKeeper->getOrdersList()->addOrder(depPtr);
+    }
+
     delete[] deploymentDistribution;
 
 
 
     //ATTACK ORDERS
-    cout<<peaceKeeper->getName()<< ": No Attacking for me, thanks:)"<<endl;
+    cout << peaceKeeper->getName() << ": No Attacking for me, thanks:)" << endl;
 
 }
 
-vector<Territory*> Benevolent::toAttack(Player* peaceKeeper){
-        vector<Territory*> attacking = peaceKeeper->getTerritories();
-        return attacking;
+vector<Territory*> Benevolent::toAttack(Player* peaceKeeper) {
+    vector<Territory*> attacking = peaceKeeper->getTerritories();
+    return attacking;
 }
 
-vector<Territory*> Benevolent::toDefend(Player* peaceKeeper){
+vector<Territory*> Benevolent::toDefend(Player* peaceKeeper) {
     vector<Card*> myHand = peaceKeeper->getHand()->getHand();
 
     vector<Territory*> myLand = peaceKeeper->getTerritories();
@@ -521,17 +515,17 @@ vector<Territory*> Benevolent::toDefend(Player* peaceKeeper){
 
     vector<Territory*> weaklings;
 
-    int least = 0;
+    int least = 99999999;
 
     //check for weakest country
-    for(Territory* eachTerr: myLand){
-        if(eachTerr->getUnits() < least){
+    for (Territory* eachTerr : myLand) {
+        if (eachTerr->getUnits() < least) {
             least = eachTerr->getUnits();
         }
     }
     //All units that are equally the weakest are put together
-    for(Territory* eachTerr:myLand){
-        if(eachTerr->getUnits() <= least){
+    for (Territory* eachTerr : myLand) {
+        if (eachTerr->getUnits() <= least) {
             weaklings.push_back(eachTerr);
         }
     }
@@ -542,54 +536,54 @@ vector<Territory*> Benevolent::toDefend(Player* peaceKeeper){
 
 /*
 computer player that never issues any order, nor uses any cards, though it may have or receive
-cards. If a Neutral player is attacked, it becomes an Aggressive player. 
+cards. If a Neutral player is attacked, it becomes an Aggressive player.
 */
-void Neutral::issueOrder(Player* relaxed,GameEngine* theGame){
+void Neutral::issueOrder(Player* relaxed, GameEngine* theGame) {
 
-    
 
-    if(relaxed->getBeenAttacked())
+
+    if (relaxed->getBeenAttacked())
         relaxed->setStrategy(new Aggressive());
-    
+
 
 }
 
-vector<Territory*> Neutral::toAttack(Player* passive){
-        vector<Territory*> attacking = passive->getTerritories();
-        return attacking;
+vector<Territory*> Neutral::toAttack(Player* passive) {
+    vector<Territory*> attacking = passive->getTerritories();
+    return attacking;
 
 }
 
-vector<Territory*> Neutral::toDefend(Player* passive){
-    vector<Territory*> defending = passive->getTerritories();    
+vector<Territory*> Neutral::toDefend(Player* passive) {
+    vector<Territory*> defending = passive->getTerritories();
     return defending;
 }
 
 /*
 computer player that automatically conquers all territories that are adjacent to its own
-territories (only once per turn). Does not use cards, though it may have or receive cards. 
+territories (only once per turn). Does not use cards, though it may have or receive cards.
 */
-void Cheater::issueOrder(Player* hacker,GameEngine* theGame){
+void Cheater::issueOrder(Player* hacker, GameEngine* theGame) {
 
     //DEFENSE PHASE
 
 
     //ATTACK PHASE
-    
+
     vector<Territory*> attackThem = hacker->toAttack();
 
     Territory* space;
 
-    for(Territory* targets:attackThem){
+    for (Territory* targets : attackThem) {
         targets->setOwner(hacker);
 
-        cout<< hacker->getName() << " now owns " << targets->getName()<<endl;
+        cout << hacker->getName() << " now owns " << targets->getName() << endl;
 
     }
-   
+
 }
 
-vector<Territory*> Cheater::toAttack(Player* hacker){
+vector<Territory*> Cheater::toAttack(Player* hacker) {
 
     //all enemy territories surrounding owned territories
     vector<Territory*> surroundings = hacker->getSurroundings();
@@ -599,7 +593,7 @@ vector<Territory*> Cheater::toAttack(Player* hacker){
 
 }
 
-vector<Territory*> Cheater::toDefend(Player* hacker){
+vector<Territory*> Cheater::toDefend(Player* hacker) {
     vector<Territory*> defending = hacker->getTerritories();
     return defending;
 }

--- a/src/PlayerStrategiesDriver.cpp
+++ b/src/PlayerStrategiesDriver.cpp
@@ -1,9 +1,9 @@
 #include "../include/PlayerStrategies.h"
 
-void testPlayerStrategies(){
+void testPlayerStrategies() {
     GameEngine warzone("start");
 
-    warzone.loadMap("loadmap Map/Earth.map");
+    warzone.loadMap("loadmap src/Map/Earth.map");
 
     warzone.validateMap();
 
@@ -19,10 +19,9 @@ void testPlayerStrategies(){
     vector<Player*> gamers = warzone.getPlayers();
 
 
-    for(Player* player: gamers){
-        player->setStrategy(new Benevolent());
-    }
-    
+    gamers[0]->setStrategy(new Benevolent());
+    gamers[1]->setStrategy(new Aggressive());
+
 
     warzone.gameStart();
 

--- a/src/Territory.cpp
+++ b/src/Territory.cpp
@@ -7,7 +7,7 @@ class Continent;
 Territory::Territory() {}
 Territory::Territory(const string& name) : name(name), armyUnits(0) {}
 
-Territory::Territory(const Territory& other):name(other.name),adjacents(other.adjacents),x(other.x),y(other.y),continent(other.continent), armyUnits(other.armyUnits){}
+Territory::Territory(const Territory& other) : name(other.name), adjacents(other.adjacents), x(other.x), y(other.y), continent(other.continent), armyUnits(other.armyUnits) {}
 
 string Territory::getName() const { return name; }
 Continent* Territory::getContinent() const { return continent; }
@@ -30,7 +30,7 @@ void Territory::setUnits(int units) {
 	this->armyUnits = units;
 }
 
-void Territory::addUnits(int units){
+void Territory::addUnits(int units) {
 	this->armyUnits += units;
 }
 

--- a/src/TournamentDriver.cpp
+++ b/src/TournamentDriver.cpp
@@ -4,6 +4,10 @@
 #include <cstdlib>
 #include <random>
 #include <sstream>
+#include <fstream>
+
+#include "../include/GameEngine.h"
+#include "../include/CommandProcessing.h"
 using namespace std;
 
 vector<string> splitArguments(const string& input);
@@ -66,7 +70,7 @@ int testTournament() {
         }
     }
 
-    
+
 
     // Validate input
     if (mapFiles.empty() || playerStrategies.empty() || numGames < 1 || maxTurns < 10 || maxTurns > 50) {

--- a/src/cards.cpp
+++ b/src/cards.cpp
@@ -85,28 +85,28 @@ Deck::Deck(int numCards) {
 
 		cardType = i % numCardTypes;//alternates between different number of cards, for an equal amount (if the deck is a multiple of 5)
 		if (cardType == 0) {
-			Bomb* kaboom;
+			Bomb* kaboom = nullptr;
 
 			//use insert instead of push_back so that the deck is randomized to begin with
 			cards.insert(cards.begin() + index, new Card(*kaboom));
 		}
-		else if (cardType == 1){
-			Deploy* reinforcement;
+		else if (cardType == 1) {
+			Deploy* reinforcement = nullptr;
 
 			//use insert instead of push_back so that the deck is randomized to begin with
 			cards.insert(cards.begin() + index, new Card(*reinforcement));
 		}
 		else if (cardType == 2) {
 
-			Blockade* block;
+			Blockade* block = nullptr;
 			cards.insert(cards.begin() + index, new Card(*block));
 		}
 		else if (cardType == 3) {
-			Airlift* air;
+			Airlift* air = nullptr;
 			cards.insert(cards.begin() + index, new Card(*air));
 		}
 		else if (cardType == 4) {
-			Negotiate* diplomacy;
+			Negotiate* diplomacy = nullptr;
 			cards.insert(cards.begin() + index, new Card(*diplomacy));
 		}
 	}
@@ -125,7 +125,7 @@ Card& Deck::draw() {
 
 	//remove card from hand
 	cards.erase(cards.begin() + index);
-	
+
 	return *drawn;
 
 }
@@ -133,7 +133,7 @@ Card& Deck::draw() {
 
 void Deck::display() {
 	for (int i = 0; i < cards.size(); i++) {
-		cout<< cards[i]->getType()->getName()<<endl;
+		cout << cards[i]->getType()->getName() << endl;
 	}
 	cout << "\n";
 }
@@ -151,7 +151,7 @@ int Deck::getSize() {
 	return cards.size();
 }
 
-GameEngine* Deck::getGame(){
+GameEngine* Deck::getGame() {
 	return game;
 }
 
@@ -174,7 +174,7 @@ Hand::Hand() {
 	owner = new Player("Player");
 }
 
-Hand::Hand(Player* player){
+Hand::Hand(Player* player) {
 	maxSize = 10;
 	owner = player;
 }
@@ -183,7 +183,7 @@ Hand::Hand(int max) {
 	maxSize = max;
 }
 
-Hand::Hand(int max,Player* player){
+Hand::Hand(int max, Player* player) {
 	maxSize = max;
 	owner = player;
 }
@@ -196,7 +196,7 @@ Hand::Hand(const Hand& other) {
 
 void Hand::display() {
 	for (int i = 0; i < playerHand.size(); i++) {
-		cout << playerHand[i]->getType()->getName() <<endl;
+		cout << playerHand[i]->getType()->getName() << endl;
 	}
 	cout << "\n";
 }
@@ -235,6 +235,6 @@ int Hand::getSize() {
 	return playerHand.size();
 }
 
-Player* Hand::getOwner(){
+Player* Hand::getOwner() {
 	return owner;
 }


### PR DESCRIPTION
-Removing player from Participants vector before deleting them 
-Loaded map properly (overriden '=' was deleting territories that game was still referencing) 
-Infinite loop in aggressive player strategy
-Player strategies were deleting reinforcement pool before they were used 
-Added edge case handling to avoid divide by zero errors 
-Cleared ordersList at end of round to avoid segmentation faults 
-etc.